### PR TITLE
basic numpy wrapping working for more cases

### DIFF
--- a/pyquist/audio_test.py
+++ b/pyquist/audio_test.py
@@ -168,6 +168,21 @@ class TestAudioBuffer(unittest.TestCase):
         with self.assertRaises(ValueError):
             audio.resample(-1)
 
+        # Simple array manipulation
+        audio = Audio.from_array(np.zeros((2, 10), dtype=np.float32), sample_rate=44100)
+        self.assertIsInstance(audio + 0.1, Audio)
+        self.assertIsInstance(audio + audio, Audio)
+        self.assertEqual((audio + 0.1).sample_rate, audio.sample_rate)
+        self.assertIsInstance(np.concatenate([audio, audio], axis=-1), Audio)
+        self.assertEqual(np.concatenate([audio, audio], axis=-1).shape, (2, 20))
+        self.assertEqual(np.concatenate([audio, audio], axis=-1).sample_rate, audio.sample_rate)
+        self.assertEqual(np.concatenate([audio, audio], axis=0).shape, (4, 10))
+        audio_48k = Audio.from_array(np.zeros((2, 10), dtype=np.float32), sample_rate=48000)
+        with self.assertRaises(ValueError):
+            np.concatenate([audio, audio_48k], axis=-1)
+        audio_48k += 0.25
+        self.assertTrue(np.all(audio_48k == 0.25))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyquist/cli.py
+++ b/pyquist/cli.py
@@ -20,7 +20,13 @@ def _restore_sd_defaults():
         with open(_SD_DEFAULTS_PATH, "r") as f:
             _SD_DEFAULTS = json.load(f)
     for k, v in _SD_DEFAULTS.items():
-        _set_sd_default(k, v, write=False)
+        # TODO(chrisdonahue): clean up this logic
+        try:
+            _set_sd_default(k, v, write=False)
+        except ValueError as e:
+            print(f"Error restoring sounddevice defaults: {e}")
+            _SD_DEFAULTS = {}
+            return
 
 
 def _set_sd_default(name: str, value: Any, write: bool = True):


### PR DESCRIPTION
Added more functionality through array_function and array_finalize implementations.

Now, simple operations like the following work, and are able to be played as intended, e.g.:
- `audio + audio`
- `np.concatenate([audio, audio], axis=-1)`
- `audio * 1.5`

I also fixed a bug in sounddevice, where if a device is removed it would cause a crash:
- “ValueError: Output device 'External Headphones' not found”, even when re-running `python -m pyquist.cli devices` to try to fix it