### PR TITLE
quick fix to ensure subdirectories in cache created

### DIFF
--- a/pyquist/web/freesound.py
+++ b/pyquist/web/freesound.py
@@ -11,6 +11,7 @@ from ..audio import Audio
 from ..paths import CACHE_DIR as _ROOT_CACHE_DIR
 
 _CACHE_DIR = _ROOT_CACHE_DIR / "freesound"
+_CACHE_DIR.mkdir(parents=True, exist_ok=True)
 
 
 def _get_client_credentials(reauthenticate: bool) -> Tuple[str, str]:

--- a/pyquist/web/theorytab.py
+++ b/pyquist/web/theorytab.py
@@ -11,6 +11,7 @@ from ..paths import CACHE_DIR as _ROOT_CACHE_DIR
 from ..score import BasicMetronome, Metronome, Score
 
 _CACHE_DIR = _ROOT_CACHE_DIR / "theorytab"
+_CACHE_DIR.mkdir(parents=True, exist_ok=True)
 
 _THEORYTAB_SCALE_NAME_TO_PITCH_INTERVALS = {
     "major": (2, 2, 1, 2, 2, 2),


### PR DESCRIPTION
cases when running fetch_audio would fail due to the .cache/pyquist/freesound directory not being created; fixed by adding top-level module code.