### PR TITLE
fixed floating point issue

### DIFF
--- a/pyquist/score.py
+++ b/pyquist/score.py
@@ -1,4 +1,5 @@
 import abc
+import math
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from .audio import Audio
@@ -69,7 +70,7 @@ def render_score(score: PlayableScore, metronome: Optional[Metronome] = None) ->
     # Output audio
     output = Audio(
         num_channels=num_channels,
-        num_samples=int(duration * sample_rate),
+        num_samples=math.ceil(duration * sample_rate),
         sample_rate=sample_rate,
     )
 


### PR DESCRIPTION
Issue with directly calling int() instead of ceil() for duration in samples for `render_score`

With floating point arithmetic, the argument sometimes is close to whole but not quite (e.g., duration of 4.1 and sample rate of 44100 -> 180809.99999999997)