### PR TITLE
Browser recording feature

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,6 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-# In-browser microphone recording (Pyodide / JupyterLite). pyquist.record()
-# delegates to this when running under Pyodide; it is never needed natively.
 browser = [
     "browseraudio>=0.1.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,11 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# In-browser microphone recording (Pyodide / JupyterLite). pyquist.record()
+# delegates to this when running under Pyodide; it is never needed natively.
+browser = [
+    "browseraudio>=0.1.0",
+]
 dev = [
     "mypy>=1.13",
     "pre-commit>=4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
 
 [project.optional-dependencies]
 browser = [
-    "browseraudio>=0.1.0",
+    "browseraudio>=0.1.2",
 ]
 dev = [
     "mypy>=1.13",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
 
 [project.optional-dependencies]
 browser = [
-    "browseraudio>=0.1.2",
+    "browseraudio>=0.3.0",
 ]
 dev = [
     "mypy>=1.13",

--- a/pyquist/__init__.py
+++ b/pyquist/__init__.py
@@ -4,6 +4,7 @@ from .audio import Audio
 from .device import (
     play,
     record,
+    record_widget,
     set_input_device,
     set_output_device,
 )
@@ -28,6 +29,7 @@ __all__ = [
     "plot_freq",
     "plot_spec",
     "record",
+    "record_widget",
     "set_input_device",
     "set_output_device",
 ]

--- a/pyquist/__init__.py
+++ b/pyquist/__init__.py
@@ -4,7 +4,6 @@ from .audio import Audio
 from .device import (
     play,
     record,
-    record_widget,
     set_input_device,
     set_output_device,
 )
@@ -29,7 +28,6 @@ __all__ = [
     "plot_freq",
     "plot_spec",
     "record",
-    "record_widget",
     "set_input_device",
     "set_output_device",
 ]

--- a/pyquist/device.py
+++ b/pyquist/device.py
@@ -155,17 +155,19 @@ def record(
         progress_bar: Whether to display a tqdm progress bar.
         browser: If True, record in the browser via the Web Audio API instead
             of a PortAudio device — for Pyodide / JupyterLite, where no audio
-            device exists. Delegates to the optional ``browseraudio`` package;
-            because browser capture is interactive, it returns a
-            ``browseraudio.Recorder`` (display it, click **Record**, then call
-            ``recorder.to_pyquist()`` in a later cell) rather than an ``Audio``.
+            device exists. Shows a Record button and returns an ``Audio`` that
+            is filled in place once the user clicks Record. (Browser capture is
+            interactive, so the returned ``Audio`` is empty until then; read it
+            in a later cell, after recording.) Requires the optional
+            ``browseraudio`` package.
 
     Returns:
-        The recorded Audio at the input device's native sample rate — or, with
-        ``browser=True``, a ``browseraudio.Recorder`` (see above).
+        The recorded Audio at the input device's native sample rate. With
+        ``browser=True`` the same ``Audio`` is returned immediately and
+        populated when the user clicks Record.
     """
     if browser:
-        return _record_in_browser(duration)  # type: ignore[return-value]
+        return _record_in_browser(duration)
     device_info = sd.query_devices(sd.default.device[0])
     sample_rate = round(device_info["default_samplerate"])
     num_channels = device_info["max_input_channels"]
@@ -185,10 +187,13 @@ def record(
     return Audio(samples, sample_rate=sample_rate)
 
 
-def _record_in_browser(duration: float):
+def _record_in_browser(duration: float) -> Audio:
     """Browser recording via the optional ``browseraudio`` package (Web Audio).
 
-    Returns a ``browseraudio.Recorder``; see :func:`record` (``browser=True``).
+    Displays a Record widget and returns an :class:`Audio` straight away; the
+    capture is interactive, so the returned object starts empty and is filled
+    in place when the user clicks Record (a kernel-idle widget-comm message).
+    See :func:`record` (``browser=True``).
     """
     try:
         import browseraudio
@@ -197,7 +202,18 @@ def _record_in_browser(duration: float):
             "In-browser recording needs the 'browseraudio' package — install "
             "pyquist[browser] (or `pip install browseraudio`)."
         ) from e
-    return browseraudio.record(duration)
+    import numpy as np
+
+    recorder = browseraudio.record(duration)  # displays the Record button
+    audio = Audio(np.zeros((1, 1), dtype=np.float32), sample_rate=None)
+
+    def _fill(_change) -> None:
+        if recorder.samples is not None:
+            audio.samples = recorder.samples
+            audio.sample_rate = recorder.sample_rate
+
+    recorder.observe(_fill, names="_pcm_b64")
+    return audio
 
 
 def _resolve_device(device_id_or_name: DeviceRef, kind: str) -> Tuple[int, str]:

--- a/pyquist/device.py
+++ b/pyquist/device.py
@@ -141,16 +141,31 @@ def play(
         sd.wait()
 
 
-def record(duration: float, *, progress_bar: bool = True, **kwargs: Any) -> Audio:
+def record(
+    duration: float,
+    *,
+    progress_bar: bool = True,
+    browser: bool = False,
+    **kwargs: Any,
+) -> Audio:
     """Records audio from the default input device.
 
     Args:
         duration: Recording length in seconds.
         progress_bar: Whether to display a tqdm progress bar.
+        browser: If True, record in the browser via the Web Audio API instead
+            of a PortAudio device — for Pyodide / JupyterLite, where no audio
+            device exists. Delegates to the optional ``browseraudio`` package;
+            because browser capture is interactive, it returns a
+            ``browseraudio.Recorder`` (display it, click **Record**, then call
+            ``recorder.to_pyquist()`` in a later cell) rather than an ``Audio``.
 
     Returns:
-        The recorded Audio at the input device's native sample rate.
+        The recorded Audio at the input device's native sample rate — or, with
+        ``browser=True``, a ``browseraudio.Recorder`` (see above).
     """
+    if browser:
+        return _record_in_browser(duration)  # type: ignore[return-value]
     device_info = sd.query_devices(sd.default.device[0])
     sample_rate = round(device_info["default_samplerate"])
     num_channels = device_info["max_input_channels"]
@@ -170,24 +185,10 @@ def record(duration: float, *, progress_bar: bool = True, **kwargs: Any) -> Audi
     return Audio(samples, sample_rate=sample_rate)
 
 
-def record_widget(duration: float = 3.0):
-    """Interactive in-browser microphone recorder (Pyodide / JupyterLite).
+def _record_in_browser(duration: float):
+    """Browser recording via the optional ``browseraudio`` package (Web Audio).
 
-    Unlike :func:`record` — which needs a PortAudio device and so is
-    unavailable in the browser — this captures from the microphone via the Web
-    Audio API, delegating to the optional ``browseraudio`` package. Because
-    browser capture is interactive and asynchronous, it returns a
-    ``browseraudio.Recorder`` rather than an :class:`~pyquist.audio.Audio`:
-    display it, click **Record**, then call ``recorder.to_pyquist()`` in a
-    later cell.
-
-    Requires ``browseraudio`` (``pip install pyquist[browser]``).
-
-    Args:
-        duration: Recording length in seconds.
-
-    Returns:
-        A ``browseraudio.Recorder`` widget.
+    Returns a ``browseraudio.Recorder``; see :func:`record` (``browser=True``).
     """
     try:
         import browseraudio

--- a/pyquist/device.py
+++ b/pyquist/device.py
@@ -12,6 +12,7 @@ from typing import Any, Optional, Tuple, Union
 
 import sounddevice as sd
 import tqdm
+import numpy as np
 
 from .audio import Audio
 from .paths import CACHE_DIR
@@ -95,6 +96,18 @@ def _in_ipython_notebook() -> bool:
     return ipy.__class__.__name__ != "TerminalInteractiveShell"
 
 
+def _in_browser() -> bool:
+    """Returns True if running inside a browser-hosted Python runtime.
+
+    Pyodide (and JupyterLite, which runs a Pyodide kernel) compiles
+    CPython to WebAssembly via Emscripten, so ``sys.platform`` reports
+    ``"emscripten"``. In these environments there is no OS audio device, so
+    capture and playback must go through the Web Audio API rather than
+    :mod:`sounddevice`.
+    """
+    return sys.platform == "emscripten"
+
+
 def play(
     audio: Audio,
     *,
@@ -145,25 +158,24 @@ def record(
     duration: float,
     *,
     progress_bar: bool = True,
-    browser: bool = False,
     **kwargs: Any,
 ) -> Audio:
     """Records audio from the default input device.
 
-    With ``browser=True`` (for Pyodide / JupyterLite, where there is no audio
-    device) recording is delegated to the optional ``browseraudio`` package via
-    the Web Audio API. Browser capture is interactive, so it shows a Record
-    button and returns an ``Audio`` that is filled in once the user clicks it.
+    In a browser-hosted runtime (Pyodide / JupyterLite, where there is no audio
+    device) recording is delegated automatically to the optional ``browseraudio``
+    package via the Web Audio API. Browser capture is interactive, so it shows a
+    Record button and returns an ``Audio`` that is filled in once the user clicks
+    it. Everywhere else, recording goes through :mod:`sounddevice`.
 
     Args:
         duration: Recording length in seconds.
         progress_bar: Whether to display a tqdm progress bar.
-        browser: If True, record in the browser instead of via sounddevice.
 
     Returns:
         The recorded Audio at the input device's native sample rate.
     """
-    if browser:
+    if _in_browser():
         return _record_in_browser(duration)
     device_info = sd.query_devices(sd.default.device[0])
     sample_rate = round(device_info["default_samplerate"])
@@ -197,7 +209,6 @@ def _record_in_browser(duration: float) -> Audio:
             "In-browser recording needs the 'browseraudio' package — install "
             "pyquist[browser] (or `pip install browseraudio`)."
         ) from e
-    import numpy as np
 
     recorder = browseraudio.record(duration)
     audio = Audio(np.zeros((1, 1), dtype=np.float32), sample_rate=None)

--- a/pyquist/device.py
+++ b/pyquist/device.py
@@ -150,21 +150,18 @@ def record(
 ) -> Audio:
     """Records audio from the default input device.
 
+    With ``browser=True`` (for Pyodide / JupyterLite, where there is no audio
+    device) recording is delegated to the optional ``browseraudio`` package via
+    the Web Audio API. Browser capture is interactive, so it shows a Record
+    button and returns an ``Audio`` that is filled in once the user clicks it.
+
     Args:
         duration: Recording length in seconds.
         progress_bar: Whether to display a tqdm progress bar.
-        browser: If True, record in the browser via the Web Audio API instead
-            of a PortAudio device — for Pyodide / JupyterLite, where no audio
-            device exists. Shows a Record button and returns an ``Audio`` that
-            is filled in place once the user clicks Record. (Browser capture is
-            interactive, so the returned ``Audio`` is empty until then; read it
-            in a later cell, after recording.) Requires the optional
-            ``browseraudio`` package.
+        browser: If True, record in the browser instead of via sounddevice.
 
     Returns:
-        The recorded Audio at the input device's native sample rate. With
-        ``browser=True`` the same ``Audio`` is returned immediately and
-        populated when the user clicks Record.
+        The recorded Audio at the input device's native sample rate.
     """
     if browser:
         return _record_in_browser(duration)
@@ -188,12 +185,10 @@ def record(
 
 
 def _record_in_browser(duration: float) -> Audio:
-    """Browser recording via the optional ``browseraudio`` package (Web Audio).
+    """Records via ``browseraudio`` (the Web Audio backend for :func:`record`).
 
-    Displays a Record widget and returns an :class:`Audio` straight away; the
-    capture is interactive, so the returned object starts empty and is filled
-    in place when the user clicks Record (a kernel-idle widget-comm message).
-    See :func:`record` (``browser=True``).
+    Returns the ``Audio`` immediately and fills it in once the user clicks
+    Record, since browser capture is interactive.
     """
     try:
         import browseraudio
@@ -204,7 +199,7 @@ def _record_in_browser(duration: float) -> Audio:
         ) from e
     import numpy as np
 
-    recorder = browseraudio.record(duration)  # displays the Record button
+    recorder = browseraudio.record(duration)
     audio = Audio(np.zeros((1, 1), dtype=np.float32), sample_rate=None)
 
     def _fill(_change) -> None:

--- a/pyquist/device.py
+++ b/pyquist/device.py
@@ -162,12 +162,6 @@ def record(
 ) -> Audio:
     """Records audio from the default input device.
 
-    In a browser-hosted runtime (Pyodide / JupyterLite, where there is no audio
-    device) recording is delegated automatically to the optional ``browseraudio``
-    package via the Web Audio API. Browser capture is interactive, so it shows a
-    Record button and returns an ``Audio`` that is filled in once the user clicks
-    it. Everywhere else, recording goes through :mod:`sounddevice`.
-
     Args:
         duration: Recording length in seconds.
         progress_bar: Whether to display a tqdm progress bar.
@@ -175,8 +169,11 @@ def record(
     Returns:
         The recorded Audio at the input device's native sample rate.
     """
+
+    # :mod:`sounddevice` is not available when running in browser, handle separately.
     if _in_browser():
         return _record_in_browser(duration)
+    
     device_info = sd.query_devices(sd.default.device[0])
     sample_rate = round(device_info["default_samplerate"])
     num_channels = device_info["max_input_channels"]
@@ -199,8 +196,8 @@ def record(
 def _record_in_browser(duration: float) -> Audio:
     """Records via ``browseraudio`` (the Web Audio backend for :func:`record`).
 
-    Returns the ``Audio`` immediately and fills it in once the user clicks
-    Record, since browser capture is interactive.
+    Returns an empty ``Audio`` that fills in once the user clicks Record (read it
+    in a later cell); failures are printed to stderr.
     """
     try:
         import browseraudio
@@ -213,12 +210,14 @@ def _record_in_browser(duration: float) -> Audio:
     recorder = browseraudio.record(duration)
     audio = Audio(np.zeros((1, 1), dtype=np.float32), sample_rate=None)
 
-    def _fill(_change) -> None:
-        if recorder.samples is not None:
-            audio.samples = recorder.samples
-            audio.sample_rate = recorder.sample_rate
+    def _fill(rec) -> None:
+        audio.samples = rec.samples
+        audio.sample_rate = rec.sample_rate
 
-    recorder.observe(_fill, names="_pcm_b64")
+    recorder.on_result(_fill)
+    recorder.on_error(
+        lambda msg: print(f"In-browser recording failed: {msg}", file=sys.stderr)
+    )
     return audio
 
 

--- a/pyquist/device.py
+++ b/pyquist/device.py
@@ -170,6 +170,35 @@ def record(duration: float, *, progress_bar: bool = True, **kwargs: Any) -> Audi
     return Audio(samples, sample_rate=sample_rate)
 
 
+def record_widget(duration: float = 3.0):
+    """Interactive in-browser microphone recorder (Pyodide / JupyterLite).
+
+    Unlike :func:`record` — which needs a PortAudio device and so is
+    unavailable in the browser — this captures from the microphone via the Web
+    Audio API, delegating to the optional ``browseraudio`` package. Because
+    browser capture is interactive and asynchronous, it returns a
+    ``browseraudio.Recorder`` rather than an :class:`~pyquist.audio.Audio`:
+    display it, click **Record**, then call ``recorder.to_pyquist()`` in a
+    later cell.
+
+    Requires ``browseraudio`` (``pip install pyquist[browser]``).
+
+    Args:
+        duration: Recording length in seconds.
+
+    Returns:
+        A ``browseraudio.Recorder`` widget.
+    """
+    try:
+        import browseraudio
+    except ImportError as e:
+        raise RuntimeError(
+            "In-browser recording needs the 'browseraudio' package — install "
+            "pyquist[browser] (or `pip install browseraudio`)."
+        ) from e
+    return browseraudio.record(duration)
+
+
 def _resolve_device(device_id_or_name: DeviceRef, kind: str) -> Tuple[int, str]:
     """Resolves an int ID or name substring to a ``(device_id, device_name)`` pair.
 

--- a/pyquist/device.py
+++ b/pyquist/device.py
@@ -214,6 +214,7 @@ def _record_in_browser(duration: float) -> Audio:
         audio.samples = rec.samples
         audio.sample_rate = rec.sample_rate
 
+    # TODO: Figure out how to make this a synchronous, blocking call.
     recorder.on_result(_fill)
     recorder.on_error(
         lambda msg: print(f"In-browser recording failed: {msg}", file=sys.stderr)

--- a/pyquist/device_test.py
+++ b/pyquist/device_test.py
@@ -3,6 +3,7 @@ import io
 import json
 import tempfile
 import unittest
+import numpy as np
 from pathlib import Path
 from unittest import mock
 
@@ -502,6 +503,57 @@ class TestInIPythonNotebook(unittest.TestCase):
         # Simulate IPython being missing entirely.
         with mock.patch.dict("sys.modules", {"IPython": None}):
             self.assertFalse(device._in_ipython_notebook())
+
+
+class TestInBrowser(unittest.TestCase):
+    """``_in_browser`` must recognise browser-hosted runtimes (Pyodide /
+    JupyterLite) so that ``record`` delegates to the Web Audio backend instead
+    of calling sounddevice, which would crash where there is no audio device."""
+
+    def test_emscripten_platform_detected(self):
+        with mock.patch.object(device.sys, "platform", "emscripten"):
+            self.assertTrue(device._in_browser())
+
+    def test_native_platform_not_detected(self):
+        for platform_name in ("darwin", "linux", "win32"):
+            with mock.patch.object(device.sys, "platform", platform_name):
+                self.assertFalse(device._in_browser())
+
+
+class TestRecordDispatch(unittest.TestCase):
+    """``record`` picks the right backend based on context."""
+
+    def test_uses_browser_in_browser(self):
+        sentinel = object()
+        with (
+            mock.patch.object(device, "_in_browser", return_value=True),
+            mock.patch.object(
+                device, "_record_in_browser", return_value=sentinel
+            ) as mock_browser,
+            mock.patch.object(device.sd, "rec") as mock_rec,
+        ):
+            result = device.record(1.0, progress_bar=False)
+            self.assertIs(result, sentinel)
+            mock_browser.assert_called_once_with(1.0)
+            mock_rec.assert_not_called()
+
+    def test_uses_sounddevice_outside_browser(self):
+        with (
+            mock.patch.object(device, "_in_browser", return_value=False),
+            mock.patch.object(device, "_record_in_browser") as mock_browser,
+            mock.patch.object(
+                device.sd,
+                "query_devices",
+                return_value={"default_samplerate": 44100, "max_input_channels": 1},
+            ),
+            mock.patch.object(
+                device.sd, "rec", return_value=np.zeros((44100, 1), dtype=np.float32)
+            ) as mock_rec,
+            mock.patch.object(device.sd, "wait"),
+        ):
+            device.record(1.0, progress_bar=False)
+            mock_rec.assert_called_once()
+            mock_browser.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`pq.record(browser=True)` records in the browser, such as Pyodide or JupyterLite, where there is no PortAudio device available. It does this by delegating to the optional `browseraudio` package through the Web Audio API. `browser=False` remains the default, so native recording is untouched.

[`browseraudio`](https://pypi.org/project/browseraudio/) is 100% vibe coded by me in an afternoon. I did some research into bridging this gap but couldn’t find an existing solution that fit, so I figured, why not write one ourselves? It has not been robustly tested yet, but the [template](https://gclef-cmu.org/icmbook/content/template-notebook.html#record-your-own-audio-live-only) works as expected.
